### PR TITLE
Support custom report filenames via toBeAccessible

### DIFF
--- a/.changeset/shiny-crabs-reflect.md
+++ b/.changeset/shiny-crabs-reflect.md
@@ -1,0 +1,5 @@
+---
+'expect-axe-playwright': minor
+---
+
+Support custom report filenames via toBeAccessible

--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ const config: PlaywrightTestConfig = {
 export default config
 ```
 
+#### Report options
+
+You can configure options that should be passed to the aXe HTML reporter at
+the assertion level.
+
+```js
+await expect(page.locator('#my-element')).toBeAccessible({
+  filename: 'my-report.html',
+})
+```
+
+This is particularly useful if you need to produce multiple aXe reports within
+the same test as it would otherwise keep replacing the same report every time
+you run the assertion.
+
 ## Thanks
 
 - [axe-playwright](https://github.com/abhinaba-ghosh/axe-playwright) for the

--- a/global.d.ts
+++ b/global.d.ts
@@ -11,6 +11,12 @@ interface MatcherOptions extends RunOptions {
    * Maximum time in milliseconds, defaults to 5 seconds.
    */
   timeout?: number
+
+  /**
+   * Custom report filename
+   * @default 'axe-report.html'
+   */
+  filename?: string
 }
 
 interface AxePlaywrightMatchers<R> {

--- a/src/matchers/toBeAccessible/index.spec.ts
+++ b/src/matchers/toBeAccessible/index.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { attachmentExists } from '../../utils/attachments'
 import { readFile } from '../../utils/file'
 
 test.describe.parallel('toBeAccessible', () => {
@@ -108,5 +109,24 @@ test.describe.parallel('toBeAccessible', () => {
     const duration = Date.now() - start
     expect(duration).toBeGreaterThan(1000)
     expect(duration).toBeLessThan(1500)
+  })
+
+  test('default report filename', async ({ page }) => {
+    const content = await readFile('inaccessible.html')
+    await page.setContent(content)
+    await expect(page)
+      .toBeAccessible({ timeout: 2000 })
+      .catch(() => Promise.resolve())
+    expect(attachmentExists('axe-report.html')).toBe(true)
+  })
+
+  test('should allow providing custom report filename', async ({ page }) => {
+    const filename = 'custom-report.html'
+    const content = await readFile('inaccessible.html')
+    await page.setContent(content)
+    await expect(page)
+      .toBeAccessible({ timeout: 2000, filename })
+      .catch(() => Promise.resolve())
+    expect(attachmentExists(filename)).toBe(true)
   })
 })

--- a/src/matchers/toBeAccessible/index.ts
+++ b/src/matchers/toBeAccessible/index.ts
@@ -15,6 +15,7 @@ const summarize = (violations: Result[]) =>
 
 interface MatcherOptions extends RunOptions {
   timeout?: number
+  filename?: string
 }
 
 export async function toBeAccessible(
@@ -42,7 +43,8 @@ export async function toBeAccessible(
     // visibility into the issue.
     if (!ok) {
       const html = await createHTMLReport(results)
-      await attach(info, 'axe-report.html', html)
+      const filename = opts.filename || 'axe-report.html'
+      await attach(info, filename, html)
     }
 
     return {

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs/promises'
-import { TestInfo } from '@playwright/test'
+import { test, TestInfo } from '@playwright/test'
 
 export async function attach(info: TestInfo, name: string, data: string) {
   const outPath = path.join(info.outputPath(), name)
@@ -13,4 +13,8 @@ export async function attach(info: TestInfo, name: string, data: string) {
     path: outPath,
     contentType: `application/${path.extname(name)}`,
   })
+}
+
+export function attachmentExists(name: string) {
+  return test.info().attachments.some((attachment) => attachment.name === name)
 }


### PR DESCRIPTION
> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

I did not know it was recommended to raise a issue for discussion until creating the PR and seeing this template.

This change is to support passing in a custom report filename into the toBeAccessible assertion to allow for multiple axe reports to be generated within a single test; without this change generated reports are continuously overwritten each time you call toBeAccessible (whether that is on the page or a locator).
