### PR TITLE
Add `reports` key to options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ This is particularly useful if you need to produce multiple aXe reports within
 the same test as it would otherwise keep replacing the same report every time
 you run the assertion.
 
+Two report types are supported: HTML and JSON. You can pass options for each
+separately:
+
+```js
+await expect(page.locator('#my-element')).toBeAccessible({
+  reports: {
+    html: {
+      // By default, this library attaches the HTML report on failure,
+      // but you can override this behaviour with attach='on' or 'off'
+      attach: 'retain-on-failure', // 'on' | 'off' | 'retain-on-failure'
+      filename: 'axe-report-on-my-element.html',
+    },
+    json: {
+      attach: 'on', // 'on' | 'off' | 'retain-on-failure'
+      filename: 'axe-report-on-my-element.json',
+      space: 0, // third argument to JSON.stringify
+    },
+  }
+})
+```
+
+These same options can also be defined at the project level inside the
+`axeOptions` object descibed above.
+
 ## Thanks
 
 - [axe-playwright](https://github.com/abhinaba-ghosh/axe-playwright) for the


### PR DESCRIPTION
## Current behavior before this pull request

If test fails, attach Axe results to failing test as HTML file.

## Changed behavior

Allow client to specify via config the format of Axe results (HTML, JSON) and when Axe results should be attached to test: always ('on'), never ('off'), or only when test fails ('retain-on-failure'). Note these names are patterned after the Playwright config for trace and video attachments.

If the client doesn't use the new `reports` key, the current behavior is maintained for backwards-compatibility.

## Background / motivation

Refer to discussion in [issue #21](https://github.com/Widen/expect-axe-playwright/issues/21)